### PR TITLE
fix: pin `jest-environment-jsdom` to v28 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "jest-environment-jsdom": "^29.7.0"
   },
   "peerDependencies": {
-    "jest-environment-jsdom": "*"
+    "jest-environment-jsdom": ">=28.0.0"
   }
 }


### PR DESCRIPTION
Pinning the minimal version of the `jest-environmnet-jsdom` peer-dependency to v28 (>=). The `default` export was added on this version only, and you'd get an error if trying to use it with a version before that one.

<details>
  <summary>Jest v28</summary>
  
  ![image](https://github.com/user-attachments/assets/2d1b18ee-709c-4f4b-9f78-b8fb78fc7a30)

</details>

<details>
  <summary>Jest v27.5.1 (latest on 27)</summary>
  
  ![image](https://github.com/user-attachments/assets/5f8fa192-2c14-4728-9b3f-213711c632ce)

</details>

