### PR TITLE
fix: support native `URLSearchParams`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This project "fixes" the following global APIs, overriding whichever polyfills t
 - `TextDecoderStream`
 - `structuredClone()`
 - `URL`
+- `URLSearchParams`
 
 ## Getting started
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
     this.global.fetch = fetch
     this.global.structuredClone = structuredClone
     this.global.URL = URL
+    this.global.URLSearchParams = URLSearchParams
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -132,3 +132,13 @@ test('exposes "URL"', () => {
   expect(globalThis).toHaveProperty('URL')
   expect(new URL('http://localhost')).toBeInstanceOf(BuiltinURL)
 })
+
+test('exposes "URLSearchParams" and makes it mockable', () => {
+  jest
+    .spyOn(URLSearchParams.prototype, 'has')
+    .mockImplementation((key) => key === 'mocked_flag')
+
+  expect(globalThis).toHaveProperty('URLSearchParams')
+  expect(new URL('http://localhost?other_non_mocked_flag').searchParams.has('other_non_mocked_flag')).toBe(false)
+  expect(new URL('http://localhost?other_non_mocked_flag').searchParams.has('mocked_flag')).toBe(true)
+})


### PR DESCRIPTION
While migrating to MSW v2 we had strange, seemingly unrelated, failure in one of our tests.

After some debugging it turned out it's related to `jest-fixed-dom` replacing `URL` with native one. I don't know why exactly it's broken but I provided a test and you can check this on your own, if you are interested.

Basically, if you mock methods on `URLSearchParams` and then you access it through `URL.searchParams`, the mock won't work. By just simply adding `this.global.URLSearchParams = URLSearchParams` it will start working.