### PR TITLE
fix: support native `TextDecoderStream` and `TextEncoderStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This project "fixes" the following global APIs, overriding whichever polyfills t
 - `ReadableStream`
 - `TextEncoder`
 - `TextDecoder`
+- `TextEncoderStream`
+- `TextDecoderStream`
 - `structuredClone()`
 - `URL`
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
 
     this.global.TextDecoder = TextDecoder
     this.global.TextEncoder = TextEncoder
+    this.global.TextDecoderStream = TextDecoderStream
+    this.global.TextEncoderStream = TextEncoderStream
     this.global.ReadableStream = ReadableStream
 
     this.global.Blob = Blob

--- a/index.test.js
+++ b/index.test.js
@@ -22,6 +22,44 @@ test('exposes "TextDecoder"', () => {
   ).toBe('hello')
 })
 
+test('exposes "TextEncoderStream"', async () => {
+  expect(globalThis).toHaveProperty('TextEncoderStream')
+  expect(() => new TextEncoderStream()).not.toThrow()
+
+  const stream = new TextEncoderStream()
+  const writer = stream.writable.getWriter()
+  writer.write('hello')
+  writer.close()
+
+  const reader = stream.readable.getReader()
+  const chunks = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(...value)
+  }
+  expect(Buffer.from(chunks)).toEqual(Buffer.from(new Uint8Array([104, 101, 108, 108, 111])))
+})
+
+test('exposes "TextDecoderStream"', async () => {
+  expect(globalThis).toHaveProperty('TextDecoderStream')
+  expect(() => new TextDecoderStream()).not.toThrow()
+
+  const stream = new TextDecoderStream()
+  const writer = stream.writable.getWriter()
+  writer.write(new Uint8Array([104, 101, 108, 108, 111]))
+  writer.close()
+
+  const reader = stream.readable.getReader()
+  const chunks = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    chunks.push(value)
+  }
+  expect(chunks.join('')).toBe('hello')
+})
+
 test('exposes "ReadableStream"', () => {
   expect(globalThis).toHaveProperty('ReadableStream')
   expect(() => new ReadableStream()).not.toThrow()


### PR DESCRIPTION
Similar to https://github.com/mswjs/jest-fixed-jsdom/pull/15, during our usage of MSW v2 and `jest-fixed-jsdom` we bumped into the issue that `TextDecoderStream` and `TextEncoderStream` aren't available.

This PR add these, including tests.