### PR TITLE
fix: add `TransformStream`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This project "fixes" the following global APIs, overriding whichever polyfills t
 - `URL`
 - `URLSearchParams`
 - `BroadcastChannel`
+- `TransformStream`
 
 ## Getting started
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
     this.global.URLSearchParams = URLSearchParams
 
     this.global.BroadcastChannel = BroadcastChannel
+    this.global.TransformStream = TransformStream
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -163,3 +163,9 @@ test('exposes "BroadcastChannel"', () => {
   expect(channel).toBeInstanceOf(BuiltinBroadcastChannel)
   channel.unref()
 })
+
+test('exposes "TransformStream"', () => {
+  expect(globalThis).toHaveProperty('TransformStream')
+  const channel = new TransformStream()
+  expect(channel).toBeInstanceOf(TransformStream)
+})

--- a/index.test.js
+++ b/index.test.js
@@ -2,6 +2,7 @@ const { URL: BuiltinURL } = require('node:url')
 const {
   BroadcastChannel: BuiltinBroadcastChannel,
 } = require('node:worker_threads')
+const { TransformStream: BuiltinTransformStream } = require('node:stream/web')
 
 test('exposes "Blob"', async () => {
   expect(globalThis).toHaveProperty('Blob')
@@ -167,5 +168,5 @@ test('exposes "BroadcastChannel"', () => {
 test('exposes "TransformStream"', () => {
   expect(globalThis).toHaveProperty('TransformStream')
   const channel = new TransformStream()
-  expect(channel).toBeInstanceOf(TransformStream)
+  expect(channel).toBeInstanceOf(BuiltinTransformStream)
 })


### PR DESCRIPTION
When trying to upgrade to msw v2 I ran into an issue with the `TransformStream` global being undefined:

```
 ReferenceError: TransformStream is not defined
```

Adding this locally fixed the issue so wanted to add it into the `jest-fixed-dom` package.