### PR TITLE
fix: set `customExportConditions` to `['']`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,17 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
   constructor(...args) {
     super(...args)
 
+    /**
+     * @note Opt-out from JSDOM using browser-style resolution
+     * for dependencies. This is simply incorrect, as JSDOM is
+     * not a browser, and loading browser-oriented bundles in
+     * Node.js will break things.
+     *
+     * Consider migrating to a more modern test runner if you
+     * don't want to deal with this.
+     */
+    this.customExportConditions = args.customExportConditions || ['']
+
     this.global.TextDecoder = TextDecoder
     this.global.TextEncoder = TextEncoder
     this.global.TextDecoderStream = TextDecoderStream


### PR DESCRIPTION
Move the `customExportConditions` from userland to this package to ensure `msw/node` is resolved correctly in Jest. 