### PR TITLE
fix: using node's global AbortController and AbortSignal

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
     this.global.Request = Request
     this.global.Response = Response
     this.global.fetch = fetch
+    this.global.AbortController = AbortController
+    this.global.AbortSignal = AbortSignal
     this.global.structuredClone = structuredClone
     this.global.URL = URL
     this.global.URLSearchParams = URLSearchParams


### PR DESCRIPTION
It seems that on Node 24 on Windows, this is necessary, especially when using `@apollo/client` and `createHttpLink`. It looks like the base jsdom implementation implements these classes, but `undici` has a requirement that `AbortSignal` be an instance of node's global `AbortSignal`.

The error I was seeing is this:
```
[Network error]: TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal. TypeError: RequestInit: Expected signal ("AbortSignal {}") to be an instance of AbortSignal.
          at Object.webidl.errors.exception (node:internal/deps/undici/undici:4098:14)
          at Object.AbortSignal (node:internal/deps/undici/undici:4340:31)
          at node:internal/deps/undici/undici:10866:41
          at node:internal/deps/undici/undici:4391:16
          at Object.RequestInit (node:internal/deps/undici/undici:4373:21)
          at new Request (node:internal/deps/undici/undici:10230:34)
          at Object.construct (<my-project>\node_modules\@mswjs\interceptors\src\interceptors\ClientRequest\utils\recordRawHeaders.ts:185:33)
          at globalThis.fetch (<my-project>\node_modules\@mswjs\interceptors\src\interceptors\fetch\index.ts:52:23)
          at fetch (<my-project-code>)
          at <my-project>\node_modules\@apollo\client\link\http\createHttpLink.js:127:13
          at new Subscription (<my-project>\node_modules\zen-observable\lib\Observable.js:197:34)
          at Observable.subscribe (<my-project>\node_modules\zen-observable\lib\Observable.js:279:14)
          at <my-project>\node_modules\@apollo\client\link\context\index.js:17:45
```