### PR TITLE
fix: add WritableStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This project "fixes" the following global APIs, overriding whichever polyfills t
 - `URLSearchParams`
 - `BroadcastChannel`
 - `TransformStream`
+- `WritableStream`
 
 ## Getting started
 

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ class FixedJSDOMEnvironment extends JSDOMEnvironment {
 
     this.global.BroadcastChannel = BroadcastChannel
     this.global.TransformStream = TransformStream
+    this.global.WritableStream = WritableStream
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -2,7 +2,7 @@ const { URL: BuiltinURL } = require('node:url')
 const {
   BroadcastChannel: BuiltinBroadcastChannel,
 } = require('node:worker_threads')
-const { TransformStream: BuiltinTransformStream } = require('node:stream/web')
+const { TransformStream: BuiltinTransformStream, WritableStream: BuiltinWritableStream } = require('node:stream/web')
 
 test('exposes "Blob"', async () => {
   expect(globalThis).toHaveProperty('Blob')
@@ -169,4 +169,10 @@ test('exposes "TransformStream"', () => {
   expect(globalThis).toHaveProperty('TransformStream')
   const channel = new TransformStream()
   expect(channel).toBeInstanceOf(BuiltinTransformStream)
+})
+
+test('exposes "WritableStream"', () => {
+  expect(globalThis).toHaveProperty('WritableStream')
+  const channel = new WritableStream()
+  expect(channel).toBeInstanceOf(BuiltinWritableStream)
 })


### PR DESCRIPTION
When trying to upgrade to msw v2.12.1 I ran into an issue with the WritableStream global being undefined:

```
 ReferenceError: WritableStream is not defined
```

I can see `sse.ts` makes use of this api and adding it into jest-fixed-jsdom allows me to continue using the package. 